### PR TITLE
Refactor to use HearthDB.CardSet

### DIFF
--- a/HDTTests/Hearthstone/DeckTest.cs
+++ b/HDTTests/Hearthstone/DeckTest.cs
@@ -16,15 +16,15 @@ namespace HDTTests.Hearthstone
 			Deck d1 = new Deck();
 			Deck d2 = new Deck();
 			//just in d1
-			d1.Cards.Add(new Card("ID_1", "", Rarity.FREE, "", "ID 1", 0, "", 0, 1, "", "", 0, 0, "", new string[] { }, 0, "", ""));
+			d1.Cards.Add(new Card("ID_1", "", Rarity.FREE, "", "ID 1", 0, "", 0, 1, "", "", 0, 0, "", new string[] { }, 0, "", CardSet.BLANK));
 			//in both but diff count
-			d1.Cards.Add(new Card("ID_2", "", Rarity.FREE, "", "ID 2", 0, "", 0, 2, "", "", 0, 0, "", new string[] { }, 0, "", ""));
-			d2.Cards.Add(new Card("ID_2", "", Rarity.FREE, "", "ID 2", 0, "", 0, 3, "", "", 0, 0, "", new string[] { }, 0, "", ""));
+			d1.Cards.Add(new Card("ID_2", "", Rarity.FREE, "", "ID 2", 0, "", 0, 2, "", "", 0, 0, "", new string[] { }, 0, "", CardSet.BLANK));
+			d2.Cards.Add(new Card("ID_2", "", Rarity.FREE, "", "ID 2", 0, "", 0, 3, "", "", 0, 0, "", new string[] { }, 0, "", CardSet.BLANK));
 			//just in d2
-			d2.Cards.Add(new Card("ID_3", "", Rarity.FREE, "", "ID 3", 0, "", 0, 2, "", "", 0, 0, "", new string[] { }, 0, "", ""));
+			d2.Cards.Add(new Card("ID_3", "", Rarity.FREE, "", "ID 3", 0, "", 0, 2, "", "", 0, 0, "", new string[] { }, 0, "", CardSet.BLANK));
 			//in bth and same cont
-			d1.Cards.Add(new Card("ID_4", "", Rarity.FREE, "", "ID 4", 0, "", 0, 5, "", "", 0, 0, "", new string[] { }, 0, "", ""));
-			d2.Cards.Add(new Card("ID_4", "", Rarity.FREE, "", "ID 4", 0, "", 0, 5, "", "", 0, 0, "", new string[] { }, 0, "", ""));
+			d1.Cards.Add(new Card("ID_4", "", Rarity.FREE, "", "ID 4", 0, "", 0, 5, "", "", 0, 0, "", new string[] { }, 0, "", CardSet.BLANK));
+			d2.Cards.Add(new Card("ID_4", "", Rarity.FREE, "", "ID 4", 0, "", 0, 5, "", "", 0, 0, "", new string[] { }, 0, "", CardSet.BLANK));
 
 			IEnumerable<Card> result = d1 - d2;
 

--- a/Hearthstone Deck Tracker/Controls/Stats/ArenaRewards.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Stats/ArenaRewards.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using Hearthstone_Deck_Tracker.Enums;
 using Hearthstone_Deck_Tracker.Hearthstone;
+using HearthDb.Enums;
 
 #endregion
 
@@ -23,7 +24,6 @@ namespace Hearthstone_Deck_Tracker.Controls.Stats
 		                                                                       typeof(ArenaRewards));
 
 		private readonly Dictionary<object, string> _invalidFields = new Dictionary<object, string>();
-		private readonly string[] _validSets = {"Classic", "Goblins vs Gnomes", "The Grand Tournament"};
 		private List<string> _cardNames;
 		private bool _deletingSelection;
 

--- a/Hearthstone Deck Tracker/Controls/Stats/ArenaRewards.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/Stats/ArenaRewards.xaml.cs
@@ -24,6 +24,7 @@ namespace Hearthstone_Deck_Tracker.Controls.Stats
 		                                                                       typeof(ArenaRewards));
 
 		private readonly Dictionary<object, string> _invalidFields = new Dictionary<object, string>();
+		private readonly CardSet[] _validSets = {CardSet.EXPERT1, CardSet.PE1, CardSet.TGT, CardSet.OG};
 		private List<string> _cardNames;
 		private bool _deletingSelection;
 

--- a/Hearthstone Deck Tracker/Hearthstone/Card.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Card.cs
@@ -74,7 +74,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 
 		public Card(string id, string playerClass, Rarity rarity, string type, string name, int cost, string localizedName, int inHandCount,
 		            int count, string text, string englishText, int attack, int health, string race, string[] mechanics, int? durability,
-		            string artist, string set, List<string> alternativeNames = null, List<string> alternativeTexts = null, HearthDb.Card dbCard = null)
+		            string artist, CardSet set, List<string> alternativeNames = null, List<string> alternativeTexts = null, HearthDb.Card dbCard = null)
 		{
 			Id = id;
 			PlayerClass = playerClass;
@@ -136,7 +136,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			Durability = dbCard.Durability > 0 ? (int?)dbCard.Durability : null;
 			Mechanics = dbCard.Mechanics;
 			Artist = dbCard.ArtistName;
-			Set = HearthDbConverter.SetConverter(dbCard.Set);
+			Set = dbCard.Set;
 			foreach(var altLangStr in Config.Instance.AlternativeLanguages)
 			{
 				Language altLang;
@@ -212,7 +212,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public Visibility ShowIconsInTooltip => Type == "Spell" || Type == "Enchantment" || Type == "Hero Power" ? Visibility.Hidden : Visibility.Visible;
 
 		[XmlIgnore]
-		public string Set { get; set; }
+		public CardSet Set { get; set; }
 
 		[XmlIgnore]
 		public string Race { get; set; }

--- a/Hearthstone Deck Tracker/Hearthstone/CardDb.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CardDb.cs
@@ -19,7 +19,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 	{
 		public string CardId { get; set; }
 		public string Name { get; set; }
-		public string CardSet { get; set; }
+		public CardSet CardSet { get; set; }
 		public Rarity Rarity { get; set; }
 		public string Type { get; set; }
 		public int Attack { get; set; }

--- a/Hearthstone Deck Tracker/Hearthstone/Deck.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Deck.cs
@@ -16,6 +16,7 @@ using Hearthstone_Deck_Tracker.Enums;
 using Hearthstone_Deck_Tracker.Stats;
 using Hearthstone_Deck_Tracker.Utility;
 using Hearthstone_Deck_Tracker.Utility.Extensions;
+using HearthDb.Enums;
 
 #endregion
 
@@ -499,7 +500,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public int GetNumDivineShield() => GetMechanicCount("Divine Shield");
 		public int GetNumCombo() => GetMechanicCount("Combo");
 
-		public bool ContainsSet(string set) => Cards.Any(card => card.Set == set);
+		public bool ContainsSet(CardSet set) => Cards.Any(card => card.Set == set);
 
 		public override string ToString() => $"{Name} ({Class})";
 

--- a/Hearthstone Deck Tracker/Hearthstone/Entities/Entity.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Entities/Entity.cs
@@ -90,7 +90,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Entities
 				_cachedCard
 				?? (_cachedCard =
 					(Database.GetCardFromId(CardId)
-					 ?? new Card(string.Empty, null, Rarity.FREE, "unknown", "unknown", 0, "unknown", 0, 1, "", "", 0, 0, "unknown", null, 0, "", "")))
+					 ?? new Card(string.Empty, null, Rarity.FREE, "unknown", "unknown", 0, "unknown", 0, 1, "", "", 0, 0, "unknown", null, 0, "", CardSet.BLANK)))
 			;
 
 		[JsonIgnore]

--- a/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
@@ -13,6 +13,7 @@ using Hearthstone_Deck_Tracker.Stats;
 using Hearthstone_Deck_Tracker.Utility.Logging;
 using Hearthstone_Deck_Tracker.Windows;
 using MahApps.Metro.Controls.Dialogs;
+using HearthDb.Enums;
 
 #endregion
 
@@ -90,7 +91,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 					return null;
 				if(!DeckList.Instance.ActiveDeck?.StandardViable ?? false)
 					return Format.Wild;
-				return Entities.Values.Where(x => !string.IsNullOrEmpty(x?.CardId) && !x.Info.Created && !string.IsNullOrEmpty(x.Card.Set))
+				return Entities.Values.Where(x => !string.IsNullOrEmpty(x?.CardId) && !x.Info.Created && x.Card.Set != CardSet.NONE)
 							.Any(x => Helper.WildOnlySets.Contains(x.Card.Set)) ? Format.Wild : Format.Standard;
 			}
 		}

--- a/Hearthstone Deck Tracker/Hearthstone/HearthDbConverter.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/HearthDbConverter.cs
@@ -10,27 +10,6 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 {
 	public static class HearthDbConverter
 	{
-		public static readonly Dictionary<int, string> SetDict = new Dictionary<int, string>
-		{
-			{0, null},
-			{2, "Basic"},
-			{3, "Classic"},
-			{4, "Reward"},
-			{5, "Missions"},
-			{7, "System"},
-			{8, "Debug"},
-			{11, "Promotion"},
-			{12, "Curse of Naxxramas"},
-			{13, "Goblins vs Gnomes"},
-			{14, "Blackrock Mountain"},
-			{15, "The Grand Tournament"},
-			{16, "Credits"},
-			{17, "Hero Skins"},
-			{18, "Tavern Brawl"},
-			{20, "League of Explorers"},
-			{21, "Whispers of the Old Gods"}
-		};
-
 		public static string ConvertClass(CardClass cardClass) => (int)cardClass < 2 || (int)cardClass > 10
 																	  ? null : CultureInfo.InvariantCulture.TextInfo.ToTitleCase(cardClass.ToString().ToLowerInvariant());
 
@@ -52,11 +31,17 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			}
 		}
 
-		public static string SetConverter(CardSet set)
+		public static Dictionary<string, CardSet> UISetStringToCardSet = new Dictionary<string, CardSet>()
 		{
-			string str;
-			SetDict.TryGetValue((int)set, out str);
-			return str;
-		}
+			{ "BASIC", CardSet.CORE },
+			{ "CLASSIC", CardSet.EXPERT1 },
+			{ "PROMOTION", CardSet.PROMO },
+			{ "CURSE OF NAXXRAMAS", CardSet.FP1 },
+			{ "GOBLINS VS GNOMES", CardSet.PE1 },
+			{ "BLACKROCK MOUNTAIN", CardSet.BRM },
+			{ "THE GRAND TOURNAMENT", CardSet.TGT },
+			{ "LEAGUE OF EXPLORERS", CardSet.LOE },
+			{ "WHISPERS OF THE OLD GODS", CardSet.OG },
+		};
 	}
 }

--- a/Hearthstone Deck Tracker/Utility/Helper.cs
+++ b/Hearthstone Deck Tracker/Utility/Helper.cs
@@ -82,7 +82,7 @@ namespace Hearthstone_Deck_Tracker
 			"esES"
 		};
 
-		public static string[] WildOnlySets = new[] { CardSet.FP1, CardSet.PE1 }.Select(HearthDbConverter.SetConverter).ToArray();
+		public static CardSet[] WildOnlySets = new[] { CardSet.FP1, CardSet.PE1 };
 
 		private static Version _currentVersion;
 

--- a/Hearthstone Deck Tracker/Windows/MainWindow.NewDeck.cs
+++ b/Hearthstone Deck Tracker/Windows/MainWindow.NewDeck.cs
@@ -93,7 +93,7 @@ namespace Hearthstone_Deck_Tracker.Windows
 					// mana filter
 					if(selectedManaCost != "ALL" && ((selectedManaCost != "9+" || card.Cost < 9) && (selectedManaCost != card.Cost.ToString())))
 						continue;
-					if(selectedSet != "ALL" && !string.Equals(selectedSet, card.Set, StringComparison.InvariantCultureIgnoreCase))
+					if (selectedSet != "ALL" && HearthDbConverter.UISetStringToCardSet[selectedSet] != card.Set)
 						continue;
 					if(!(CheckBoxIncludeWild.IsChecked ?? true) && Helper.WildOnlySets.Contains(card.Set))
 						continue;
@@ -306,12 +306,12 @@ namespace Hearthstone_Deck_Tracker.Windows
 
 		private void UpdateExpansionIcons()
 		{
-			RectIconOg.Visibility = _newDeck?.ContainsSet("Whispers of the Old Gods") ?? false ? Visible : Collapsed;
-			RectIconLoe.Visibility = _newDeck?.ContainsSet("League of Explorers") ?? false ? Visible : Collapsed;
-			RectIconTgt.Visibility = _newDeck?.ContainsSet("The Grand Tournament") ?? false ? Visible : Collapsed;
-			RectIconBrm.Visibility = _newDeck?.ContainsSet("Blackrock Mountain") ?? false ? Visible : Collapsed;
-			RectIconGvg.Visibility = _newDeck?.ContainsSet("Goblins vs Gnomes") ?? false ? Visible : Collapsed;
-			RectIconNaxx.Visibility = _newDeck?.ContainsSet("Curse of Naxxramas") ?? false ? Visible : Collapsed;
+			RectIconOg.Visibility = _newDeck?.ContainsSet(CardSet.OG) ?? false ? Visible : Collapsed;
+			RectIconLoe.Visibility = _newDeck?.ContainsSet(CardSet.LOE) ?? false ? Visible : Collapsed;
+			RectIconTgt.Visibility = _newDeck?.ContainsSet(CardSet.TGT) ?? false ? Visible : Collapsed;
+			RectIconBrm.Visibility = _newDeck?.ContainsSet(CardSet.BRM) ?? false ? Visible : Collapsed;
+			RectIconGvg.Visibility = _newDeck?.ContainsSet(CardSet.PE1) ?? false ? Visible : Collapsed;
+			RectIconNaxx.Visibility = _newDeck?.ContainsSet(CardSet.FP1) ?? false ? Visible : Collapsed;
 		}
 
 		private void UpdateCardCount()

--- a/Hearthstone Deck Tracker/Windows/MessageDialogs.cs
+++ b/Hearthstone Deck Tracker/Windows/MessageDialogs.cs
@@ -19,6 +19,7 @@ using MahApps.Metro.Controls.Dialogs;
 using Microsoft.Win32;
 using static System.StringComparison;
 using static MahApps.Metro.Controls.Dialogs.MessageDialogStyle;
+using HearthDb.Enums;
 
 #endregion
 
@@ -144,15 +145,15 @@ namespace Hearthstone_Deck_Tracker.Windows
 				if(card.Count == 2)
 					message += " x2";
 
-				if(card.Set.Equals("CURSE OF NAXXRAMAS", CurrentCultureIgnoreCase))
+				if(card.Set == CardSet.FP1)
 					sets[0] = "and the Naxxramas DLC ";
-				else if(card.Set.Equals("PROMOTION", CurrentCultureIgnoreCase))
+				else if(card.Set == CardSet.PROMO)
 					sets[1] = "and Promotion cards ";
-				else if(card.Set.Equals("REWARD", CurrentCultureIgnoreCase))
+				else if(card.Set == CardSet.REWARD)
 					sets[2] = "and the Reward cards ";
-				else if(card.Set.Equals("BLACKROCK MOUNTAIN", CurrentCultureIgnoreCase))
+				else if(card.Set == CardSet.BRM)
 					sets[3] = "and the Blackrock Mountain DLC ";
-				else if(card.Set.Equals("LEAGUE OF EXPLORERS", CurrentCultureIgnoreCase))
+				else if(card.Set == CardSet.LOE)
 					sets[4] = "and the League of Explorers DLC ";
 				else
 					totalDust += card.DustCost * card.Count;


### PR DESCRIPTION
Replaced strings for sets with the HearthDB enum. 

Looking for feedback on MainWindow.xaml RadioButton and Arena rewards issues. 

The radio buttons will still use a string unless a better solution is suggested.

If arena rewards don't depend on arena start, then GVG packs should be removed from valid reward sets.
